### PR TITLE
Fix readme AbstractShardedModule import

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,8 +22,7 @@ Please take note the following requirments:
 > lib/modules/sharded/index.ts
 
 ```typescript
-import {
-  AbstractShardedModule,
+import AbstractShardedModule, {
   IShard
 } from 'mage-module-shard'
 


### PR DESCRIPTION
AbstractShardedModule was not imported correctly in the README.md.